### PR TITLE
Cleanup - Initial Project Refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,4 @@ jobs:
           go-version: 1.21
       - run: go get -v -t -d ./...
       - run: go build -v .
+      - run: go test ./... --coverprofile=cover.out

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,9 +35,7 @@ var rootCmd = &cobra.Command{
 		// config to define the types of files to process
 		types := []string{"pull_requests", "issues"}
 
-		// leaving this for now to quickly test the code
-		archivePath := "test/3723ff5e-4b7e-11ef-9bf5-2aca377420b3"
-		// archivePath, _ := cmd.Flags().GetString("migration-archive")
+		archivePath, _ := cmd.Flags().GetString("migration-archive")
 
 		commitremap.ProcessFiles(archivePath, types, commitMap)
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		// config to define the types of files to process
-		types := []string{"pull_requests", "issues"}
+		types := []string{"pull_requests", "issues", "issue_events"}
 
 		archivePath, _ := cmd.Flags().GetString("migration-archive")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,20 +4,19 @@ Copyright © 2024 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 
+	"github.com/mona-actions/gh-commit-remap/internal/commitremap"
 	"github.com/spf13/cobra"
 )
 
-// Struct to represent a single entry in the commit map
-type CommitMapEntry struct {
-	Old string
-	New string
+func init() {
+	rootCmd.Flags().StringP("mapping-file", "c", "", "Path to the commit map file Example: /path/to/commit-map")
+	rootCmd.MarkFlagRequired("mapping-file")
+
+	rootCmd.Flags().StringP("migration-archive", "m", "", "Path to the migration archive Example: /path/to/migration-archive.tar.gz")
+	rootCmd.MarkFlagRequired("migration-archive")
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -26,9 +25,22 @@ var rootCmd = &cobra.Command{
 	Short: "remaps commit hashes in a GitHub archive",
 	Long: `Is a CLI tool that can remap commits hashed 
 	after performing a history re-write when performing a migration For exam`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	Run: main,
+	Run: func(cmd *cobra.Command, args []string) {
+		mapPath, _ := cmd.Flags().GetString("mapping-file")
+		commitMap, err := commitremap.ParseCommitMap(mapPath)
+		if err != nil {
+			log.Fatalf("Error parsing commit map: %v", err)
+		}
+
+		// config to define the types of files to process
+		types := []string{"pull_requests", "issues"}
+
+		// leaving this for now to quickly test the code
+		archivePath := "test/3723ff5e-4b7e-11ef-9bf5-2aca377420b3"
+		// archivePath, _ := cmd.Flags().GetString("migration-archive")
+
+		commitremap.ProcessFiles(archivePath, types, commitMap)
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -37,147 +49,5 @@ func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
-	}
-}
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.gh-commit-remap.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().StringP("mapping-file", "c", "", "Path to the commit map file Example: /path/to/commit-map")
-	rootCmd.MarkFlagRequired("mapping-file")
-
-	rootCmd.Flags().StringP("migration-archive", "m", "", "Path to the migration archive Example: /path/to/migration-archive.tar.gz")
-	rootCmd.MarkFlagRequired("migration-archive")
-}
-
-func main(cmd *cobra.Command, args []string) {
-	// leaving this for now to quickly test the code
-	//mapPath := "test/TestRepo.git/filter-repo/commit-map"
-	mapPath, _ := cmd.Flags().GetString("mapping-file")
-	commitMap, err := parseCommitMap(mapPath)
-	if err != nil {
-		log.Fatalf("Error parsing commit map: %v", err)
-	}
-
-	// config to define the types of files to process
-	types := []string{"pull_requests", "issues"}
-
-	// leaving this for now to quickly test the code
-	//archivePath := "test/3723ff5e-4b7e-11ef-9bf5-2aca377420b3"
-	archivePath, _ := cmd.Flags().GetString("migration-archive")
-
-	processFiles(archivePath, types, commitMap)
-}
-
-// Parses the file and returns a map of old commit hashes to new commit hashes
-func parseCommitMap(filePath string) (*[]CommitMapEntry, error) {
-	commitMap := []CommitMapEntry{}
-
-	// Read the commit-map file
-	content, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-	// Split the file content into lines
-	lines := strings.Split(string(content), "\n")
-
-	// Iterate over the lines and parse the old and new commit hashes
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-
-		fields := strings.Fields(line)
-		if len(fields) != 2 {
-			return nil, fmt.Errorf("invalid line: %s", line)
-		}
-
-		commitMap = append(commitMap, CommitMapEntry{
-			Old: fields[0],
-			New: fields[1],
-		})
-	}
-	return &commitMap, nil
-}
-
-func replaceSHA(data interface{}, oldSHA string, newSHA string) {
-	if data == nil {
-		return
-	}
-
-	switch v := data.(type) {
-	case map[string]interface{}:
-		for key, value := range v {
-			if str, ok := value.(string); ok && str == oldSHA {
-				v[key] = newSHA
-			} else {
-				replaceSHA(value, oldSHA, newSHA)
-			}
-		}
-	case []interface{}:
-		for i, value := range v {
-			if str, ok := value.(string); ok && str == oldSHA {
-				v[i] = newSHA
-			} else {
-				replaceSHA(value, oldSHA, newSHA)
-			}
-		}
-	default:
-		// Unsupported type, do nothing
-	}
-}
-
-func updateMetadataFile(filePath string, commitMap *[]CommitMapEntry) {
-	// Read the JSON file
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		log.Fatalf("Error reading data: %v", err)
-	}
-
-	var dataMap interface{}
-	err = json.Unmarshal(data, &dataMap)
-	if err != nil {
-		log.Fatalf("Error unmarshaling data: %v", err)
-	}
-
-	// Iterate over the commit map and replace the old commit hashes with the new ones
-	for _, commit := range *commitMap {
-		replaceSHA(dataMap, commit.Old, commit.New)
-	}
-
-	// Marshal the updated data to JSON and pretty print it
-	updatedData, err := json.MarshalIndent(dataMap, "", "  ")
-	if err != nil {
-		log.Fatalf("Error marshaling updated data: %v", err)
-	}
-
-	// Overwrite the original file with the updated data
-	err = os.WriteFile(filePath, updatedData, 0644)
-	if err != nil {
-		log.Fatalf("Error writing updated data: %v", err)
-	}
-}
-
-func processFiles(archiveLocation string, prefixes []string, commitMap *[]CommitMapEntry) {
-
-	for _, prefix := range prefixes {
-		// Get a list of all files that match the pattern
-		files, err := filepath.Glob(filepath.Join(archiveLocation, prefix+"_*.json"))
-		if err != nil {
-			log.Fatalf("Error getting files: %v", err)
-		}
-
-		// Process each file
-		for _, file := range files {
-			log.Println("Processing file:", file)
-
-			updateMetadataFile(file, commitMap)
-		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kuhlman-labs/gh-commit-remap
+module github.com/mona-actions/gh-commit-remap
 
 go 1.22.5
 

--- a/internal/commitremap/commitremap.go
+++ b/internal/commitremap/commitremap.go
@@ -1,0 +1,123 @@
+package commitremap
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Struct to represent a single entry in the commit map
+type CommitMapEntry struct {
+	Old string
+	New string
+}
+
+// Parses the file and returns a map of old commit hashes to new commit hashes
+func ParseCommitMap(filePath string) (*[]CommitMapEntry, error) {
+	commitMap := []CommitMapEntry{}
+
+	// Read the commit-map file
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	// Split the file content into lines
+	lines := strings.Split(string(content), "\n")
+
+	// Iterate over the lines and parse the old and new commit hashes
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("invalid line: %s", line)
+		}
+
+		commitMap = append(commitMap, CommitMapEntry{
+			Old: fields[0],
+			New: fields[1],
+		})
+	}
+	return &commitMap, nil
+}
+
+func ProcessFiles(archiveLocation string, prefixes []string, commitMap *[]CommitMapEntry) {
+
+	for _, prefix := range prefixes {
+		// Get a list of all files that match the pattern
+		files, err := filepath.Glob(filepath.Join(archiveLocation, prefix+"_*.json"))
+		if err != nil {
+			log.Fatalf("Error getting files: %v", err)
+		}
+
+		// Process each file
+		for _, file := range files {
+			log.Println("Processing file:", file)
+
+			updateMetadataFile(file, commitMap)
+		}
+	}
+}
+
+func updateMetadataFile(filePath string, commitMap *[]CommitMapEntry) {
+	// Read the JSON file
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Fatalf("Error reading data: %v", err)
+	}
+
+	var dataMap interface{}
+	err = json.Unmarshal(data, &dataMap)
+	if err != nil {
+		log.Fatalf("Error unmarshaling data: %v", err)
+	}
+
+	// Iterate over the commit map and replace the old commit hashes with the new ones
+	for _, commit := range *commitMap {
+		replaceSHA(dataMap, commit.Old, commit.New)
+	}
+
+	// Marshal the updated data to JSON and pretty print it
+	updatedData, err := json.MarshalIndent(dataMap, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshaling updated data: %v", err)
+	}
+
+	// Overwrite the original file with the updated data
+	err = os.WriteFile(filePath, updatedData, 0644)
+	if err != nil {
+		log.Fatalf("Error writing updated data: %v", err)
+	}
+}
+
+func replaceSHA(data interface{}, oldSHA string, newSHA string) {
+	if data == nil {
+		return
+	}
+
+	switch v := data.(type) {
+	case map[string]interface{}:
+		for key, value := range v {
+			if str, ok := value.(string); ok && str == oldSHA {
+				v[key] = newSHA
+			} else {
+				replaceSHA(value, oldSHA, newSHA)
+			}
+		}
+	case []interface{}:
+		for i, value := range v {
+			if str, ok := value.(string); ok && str == oldSHA {
+				v[i] = newSHA
+			} else {
+				replaceSHA(value, oldSHA, newSHA)
+			}
+		}
+	default:
+		// Unsupported type, do nothing
+	}
+}

--- a/internal/commitremap/commitremap_test.go
+++ b/internal/commitremap/commitremap_test.go
@@ -1,0 +1,86 @@
+package commitremap
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseCommitMap(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileContent string
+		expected    *[]CommitMapEntry
+		expectError bool
+	}{
+		{
+			name: "Valid commit map",
+			fileContent: `oldSHA1 newSHA1
+oldSHA2 newSHA2
+oldSHA3 newSHA3`,
+			expected: &[]CommitMapEntry{
+				{Old: "oldSHA1", New: "newSHA1"},
+				{Old: "oldSHA2", New: "newSHA2"},
+				{Old: "oldSHA3", New: "newSHA3"},
+			},
+			expectError: false,
+		},
+		{
+			name:        "Empty file",
+			fileContent: ``,
+			expected:    &[]CommitMapEntry{},
+			expectError: false,
+		},
+		{
+			name: "Invalid line format",
+			fileContent: `oldSHA1 newSHA1
+invalidLine
+oldSHA2 newSHA2`,
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary file
+			tmpfile, err := os.CreateTemp("", "commitmap")
+			if err != nil {
+				t.Fatalf("Failed to create temp file: %v", err)
+			}
+			defer os.Remove(tmpfile.Name())
+
+			// Write the test content to the temporary file
+			if _, err := tmpfile.WriteString(tt.fileContent); err != nil {
+				t.Fatalf("Failed to write to temp file: %v", err)
+			}
+			if err := tmpfile.Close(); err != nil {
+				t.Fatalf("Failed to close temp file: %v", err)
+			}
+
+			// Call the function under test
+			result, err := ParseCommitMap(tmpfile.Name())
+
+			// Check for expected error
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("Expected error but got none")
+				}
+				return
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+			}
+
+			// Check the result
+			if len(*result) != len(*tt.expected) {
+				t.Fatalf("Expected %d entries, got %d", len(*tt.expected), len(*result))
+			}
+			for i, entry := range *result {
+				if entry.Old != (*tt.expected)[i].Old || entry.New != (*tt.expected)[i].New {
+					t.Errorf("Expected entry %d to be %+v, got %+v", i, (*tt.expected)[i], entry)
+				}
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,9 @@
 /*
 Copyright © 2024 NAME HERE <EMAIL ADDRESS>
-
 */
 package main
 
-import "github.com/kuhlman-labs/gh-commit-remap/cmd"
+import "github.com/mona-actions/gh-commit-remap/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
* Updated `go.mod` to reflect source repository name
* Moved commit remap logic from `cmd/root.go` into `internal/commitremap`. Chances are some functions around file processing can be broken out of here as well, but we'll see.
* Removed `func main`, and did an inline function for the root cmd. I didn't see much of a point of adding a concrete function for the root command at this point in time 🤷🏽 
* Added initial unit test around parsing commit map
* Added unit test execution as part of CI workflow