### PR TITLE
adds new retar function, checks for errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ CLI tool to remap commits during a migration after a history rewrite
 ## Install
 
 ```bash
-gh extension install kuhlman-labs/gh-commit-remap
+gh extension install mona-actions/gh-commit-remap
 ```
 
 ## Upgrade
@@ -27,5 +27,5 @@ Usage:
 Flags:
   -h, --help                       help for gh-commit-remap
   -c, --mapping-file string        Path to the commit map file Example: /path/to/commit-map
-  -m, --migration-archive string   Path to the migration archive Example: /path/to/migration-archive.tar.gz
+  -m, --migration-archive string   Path to the migration archive Example: /path/to/migration-archive
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,10 +43,12 @@ var rootCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		err = archive.ReTar(archivePath)
+		tarPath, err := archive.ReTar(archivePath)
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		log.Printf("New archive created: %s", tarPath)
 
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/mona-actions/gh-commit-remap/internal/archive"
 	"github.com/mona-actions/gh-commit-remap/internal/commitremap"
 	"github.com/spf13/cobra"
 )
@@ -37,7 +38,16 @@ var rootCmd = &cobra.Command{
 
 		archivePath, _ := cmd.Flags().GetString("migration-archive")
 
-		commitremap.ProcessFiles(archivePath, types, commitMap)
+		err = commitremap.ProcessFiles(archivePath, types, commitMap)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = archive.ReTar(archivePath)
+		if err != nil {
+			log.Fatal(err)
+		}
+
 	},
 }
 

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -8,7 +8,7 @@ import (
 
 // reTarFiles creates a new tar archive from the files in the given directory.
 // The name of the archive is the same as the directory name.
-func ReTar(archivePath string) error {
+func ReTar(archivePath string) (string, error) {
 	// Extract the directory name from the archivePath
 	dirName := filepath.Base(archivePath)
 
@@ -17,17 +17,17 @@ func ReTar(archivePath string) error {
 
 	err := checkTarAvailability()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Create and run the tar command
 	tarCmd := exec.Command("tar", "-czf", archiveName, "-C", archivePath, ".")
 	err = tarCmd.Run()
 	if err != nil {
-		return fmt.Errorf("error re-tarring the files: %w", err)
+		return "", fmt.Errorf("error re-tarring the files: %w", err)
 	}
 
-	return nil
+	return archiveName, nil
 }
 
 // checkTarAvailability checks if the 'tar' command is available in the system's PATH.

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -1,0 +1,37 @@
+package archive
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+)
+
+// reTarFiles creates a new tar archive from the files in the given directory.
+// The name of the archive is the same as the directory name.
+func ReTar(archivePath string) error {
+	// Extract the directory name from the archivePath
+	dirName := filepath.Base(archivePath)
+
+	// Create the name of the new archive
+	archiveName := dirName + ".tar.gz"
+
+	err := checkTarAvailability()
+	if err != nil {
+		return err
+	}
+
+	// Create and run the tar command
+	tarCmd := exec.Command("tar", "-czf", archiveName, "-C", archivePath, ".")
+	err = tarCmd.Run()
+	if err != nil {
+		return fmt.Errorf("error re-tarring the files: %w", err)
+	}
+
+	return nil
+}
+
+// checkTarAvailability checks if the 'tar' command is available in the system's PATH.
+func checkTarAvailability() error {
+	_, err := exec.LookPath("tar")
+	return err
+}

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -1,0 +1,64 @@
+package archive
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestReTar(t *testing.T) {
+	// Create a temporary directory
+	tempDir, err := os.MkdirTemp("", "test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a file in the temporary directory
+	tempFile := filepath.Join(tempDir, "testfile")
+	origContent := []byte("test")
+	if err := os.WriteFile(tempFile, origContent, 0644); err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	// Call the function under test
+	tarFile, err := ReTar(tempDir)
+	if err != nil {
+		t.Fatalf("ReTar failed: %v", err)
+	}
+
+	// Check if the tar file was created
+	if _, err := os.Stat(tarFile); os.IsNotExist(err) {
+		t.Fatalf("Tar file was not created: %v", err)
+	}
+
+	// Ensure the tar file is removed after the test
+	defer os.Remove(tarFile)
+
+	// Extract the tar file to a new directory
+	extractDir, err := os.MkdirTemp("", "extract")
+	if err != nil {
+		t.Fatalf("Failed to create extract directory: %v", err)
+	}
+	defer os.RemoveAll(extractDir)
+
+	tarCmd := exec.Command("tar", "-xzf", tarFile, "-C", extractDir)
+	err = tarCmd.Run()
+	if err != nil {
+		t.Fatalf("Failed to extract tar file: %v", err)
+	}
+
+	// Read the contents of the extracted file
+	extractedFile := filepath.Join(extractDir, "testfile")
+	extractedContent, err := os.ReadFile(extractedFile)
+	if err != nil {
+		t.Fatalf("Failed to read extracted file: %v", err)
+	}
+
+	// Compare the contents of the original file and the extracted file
+	if !bytes.Equal(origContent, extractedContent) {
+		t.Fatalf("Original file content and extracted file content do not match")
+	}
+}


### PR DESCRIPTION
This pull request introduces functionality for re-tarring archives and improves error handling in the `commitremap` package. Added a new `archive` package, updated the `commitremap` package to return errors, and integrating these changes into the `root` command.

> The new `.tar.gz` is created wherever the CLI tool runs instead of where the original migration archive is located 

