### PR TITLE
update release go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 #v5.0.1
         with:
-          go-version: 1.21
+          go-version: 1.22
       - run: go get -v -t -d ./...
       - run: go build -v .
       - run: go test ./... --coverprofile=cover.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
       - uses: cli/gh-extension-precompile@v1
         with:
-          go_version: 1.21
+          go_version: 1.22


### PR DESCRIPTION
This pull request includes a change that updates the Go version used in the GitHub Actions workflows for build and release the extension to match the version used by [extension itself](https://github.com/mona-actions/gh-commit-remap/blob/main/go.mod#L3)