### PR TITLE
Revert "update release go version"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 #v5.0.1
         with:
-          go-version: 1.22
+          go-version: 1.21
       - run: go get -v -t -d ./...
       - run: go build -v .
       - run: go test ./... --coverprofile=cover.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
       - uses: cli/gh-extension-precompile@v1
         with:
-          go_version: 1.22
+          go_version: 1.21


### PR DESCRIPTION
Reverts mona-actions/gh-commit-remap#5

it seems that there is an issue with [go version 1.22](https://github.com/cli/gh-extension-precompile/issues/50) that is causing the release to [fail](https://github.com/mona-actions/gh-commit-remap/actions/runs/10479709269) so I'm reverting this PR.

I'll try to release after this is merged and see if the build / release still works
