### PR TITLE
Performance Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ go.work
 go.work.sum
 
 gh-commit-remap
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ Flags:
   -h, --help                       help for gh-commit-remap
   -c, --mapping-file string        Path to the commit map file Example: /path/to/commit-map
   -m, --migration-archive string   Path to the migration archive Example: /path/to/migration-archive
+  -t, --number-of-threads int      [OPTIONAL] Number of threads(goroutines) to use for processing. Defaults to 10"
 ```

--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ Flags:
   -h, --help                       help for gh-commit-remap
   -c, --mapping-file string        Path to the commit map file Example: /path/to/commit-map
   -m, --migration-archive string   Path to the migration archive Example: /path/to/migration-archive
-  -t, --number-of-threads int      [OPTIONAL] Number of threads(goroutines) to use for processing. Defaults to 10"
+  -t, --number-of-threads int      [OPTIONAL] Number of threads(goroutines) to use for processing. 
+                                   Defaults to 10, cannot exceed 50."
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,9 @@ func init() {
 
 	rootCmd.Flags().StringP("migration-archive", "m", "", "Path to the migration archive Example: /path/to/migration-archive.tar.gz")
 	rootCmd.MarkFlagRequired("migration-archive")
+
+	// Optional flag to specify the number of threads to use for processing
+	rootCmd.Flags().StringP("number-of-threads", "t", "10", "[OPTIONAL] Number of threads(goroutines) to use for processing. Defaults to 10")
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -34,20 +37,19 @@ var rootCmd = &cobra.Command{
 		}
 
 		// config to define the types of files to process
-		types := []string{"pull_requests", "issues", "issue_events"}
+		types := []string{"pull_requests", "pull_request_reviews", "pull_request_review_comments", "pull_request_review_threads", "commit_comments"}
 
 		archivePath, _ := cmd.Flags().GetString("migration-archive")
-
-		err = commitremap.ProcessFiles(archivePath, types, commitMap)
+		workers, _ := cmd.Flags().GetInt("number-of-threads")
+		err = commitremap.ProcessFiles(archivePath, types, commitMap, workers)
 		if err != nil {
 			log.Fatal(err)
 		}
-
+		log.Printf("Processed files successfully, re-taring archive")
 		tarPath, err := archive.ReTar(archivePath)
 		if err != nil {
 			log.Fatal(err)
 		}
-
 		log.Printf("New archive created: %s", tarPath)
 
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ func init() {
 	rootCmd.MarkFlagRequired("migration-archive")
 
 	// Optional flag to specify the number of threads to use for processing
-	rootCmd.Flags().StringP("number-of-threads", "t", "10", "[OPTIONAL] Number of threads(goroutines) to use for processing. Defaults to 10")
+	rootCmd.Flags().IntP("number-of-threads", "t", 10, "[OPTIONAL] Number of threads(goroutines) to use for processing. Defaults to 10")
 }
 
 // rootCmd represents the base command when called without any subcommands
@@ -41,6 +41,12 @@ var rootCmd = &cobra.Command{
 
 		archivePath, _ := cmd.Flags().GetString("migration-archive")
 		workers, _ := cmd.Flags().GetInt("number-of-threads")
+		if workers < 1 {
+			workers = 10
+		}
+		if workers > 50 {
+			log.Fatalf("Number of threads cannot exceed 50")
+		}
 		err = commitremap.ProcessFiles(archivePath, types, commitMap, workers)
 		if err != nil {
 			log.Fatal(err)

--- a/internal/commitremap/commitremap.go
+++ b/internal/commitremap/commitremap.go
@@ -1,99 +1,137 @@
 package commitremap
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
-// Struct to represent a single entry in the commit map
-type CommitMapEntry struct {
-	Old string
-	New string
+type File struct {
+	FilePath string
+	Prefix   string
 }
 
 // Parses the file and returns a map of old commit hashes to new commit hashes
-func ParseCommitMap(filePath string) (*[]CommitMapEntry, error) {
-	commitMap := []CommitMapEntry{}
-
+func ParseCommitMap(filePath string) (*map[string]string, error) {
+	commitMap := make(map[string]string)
 	// Read the commit-map file
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
-	// Split the file content into lines
-	lines := strings.Split(string(content), "\n")
-
-	// Iterate over the lines and parse the old and new commit hashes
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" {
+	buf := bytes.NewBuffer(content)
+	scanner := bufio.NewScanner(buf)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Skip adding the header to the map
+		if line == "old                                      new" {
 			continue
 		}
-
-		fields := strings.Fields(line)
+		fields := strings.Split(line, " ")
 		if len(fields) != 2 {
 			return nil, fmt.Errorf("invalid line: %s", line)
 		}
-
-		commitMap = append(commitMap, CommitMapEntry{
-			Old: fields[0],
-			New: fields[1],
-		})
+		commitMap[fields[0]] = fields[1]
 	}
 	return &commitMap, nil
 }
 
-func ProcessFiles(archiveLocation string, prefixes []string, commitMap *[]CommitMapEntry) error {
-
-	for _, prefix := range prefixes {
-		// Get a list of all files that match the pattern
-		files, err := filepath.Glob(filepath.Join(archiveLocation, prefix+"_*.json"))
+func ProcessFiles(archiveLocation string, prefixes []string,
+	commitMap *map[string]string, workers int) error {
+	workerCount := 10
+	fileChannel := make(chan File, workerCount)
+	fileProcessWg := sync.WaitGroup{}
+	filesToProcess := getAllFilesToProcess(prefixes, archiveLocation)
+	totalFiles := len(filesToProcess)
+	processedFiles := make(chan File, totalFiles)
+	processedFilesCount := 0
+	// go routine to print out the progress of the processed files. It also
+	// writes the processed files to a log file
+	fmt.Printf("Processed %d/%d files\n", processedFilesCount, totalFiles)
+	go func() {
+		f, err := os.OpenFile("processed_files.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			log.Fatalf("Error getting files: %v", err)
+			log.Fatalf("Error opening processed files log: %v", err)
 		}
-
-		// Process each file
-		for _, file := range files {
-			log.Println("Processing file:", file)
-
-			err := updateMetadataFile(file, commitMap)
-			if err != nil {
-				return fmt.Errorf("Error updating metadata file: %v; %v", file, err)
+		defer f.Close()
+		for file := range processedFiles {
+			fmt.Printf("\033[1A\033[K")
+			fmt.Printf("Processed %d/%d files\n", processedFilesCount, totalFiles)
+			if _, err := f.WriteString(fmt.Sprintf("%s\n", file.FilePath)); err != nil {
+				log.Fatalf("Error writing to processed files log: %v", err)
 			}
 		}
+	}()
+
+	for i := 0; i < workerCount; i++ {
+		fileProcessWg.Add(1)
+		go func() {
+			defer fileProcessWg.Done()
+			for file := range fileChannel {
+				err := updateMetadataFile(file, *commitMap)
+				if err != nil {
+					log.Fatalf("Error updating metadata file: %v", err)
+				}
+				processedFiles <- file
+				processedFilesCount++
+			}
+		}()
 	}
+	prefixWg := sync.WaitGroup{}
+	// Add the files to the channel
+	for _, file := range filesToProcess {
+		prefixWg.Add(1)
+		go func(file File) {
+			defer prefixWg.Done()
+			fileChannel <- file
+		}(file)
+	}
+	prefixWg.Wait()
+	close(fileChannel)
+	fileProcessWg.Wait()
+	close(processedFiles)
 	return nil
 }
 
-func updateMetadataFile(filePath string, commitMap *[]CommitMapEntry) error {
-	// Read the JSON file
-	data, err := os.ReadFile(filePath)
+func updateMetadataFile(file File, commitMap map[string]string) error {
+	var dataMap []interface{}
+	data, err := os.ReadFile(file.FilePath)
 	if err != nil {
-		return fmt.Errorf("Error reading data: %v", err)
+		return err
 	}
 
-	var dataMap interface{}
 	err = json.Unmarshal(data, &dataMap)
 	if err != nil {
-		return fmt.Errorf("Error unmarshaling data: %v", err)
+		return err
+	}
+	switch {
+	case file.Prefix == "pull_requests":
+		updatePullRequests(commitMap, &dataMap)
+	case file.Prefix == "pull_request_review_comments":
+		updatePullRequestReviewComments(commitMap, &dataMap)
+	case file.Prefix == "pull_request_reviews":
+		updatePullRequestReviews(commitMap, &dataMap)
+	case file.Prefix == "pull_request_review_threads":
+		updatePullRequestReviewThreads(commitMap, &dataMap)
+	case file.Prefix == "commit_comments":
+		updateCommitComments(commitMap, &dataMap)
+	default:
+		return fmt.Errorf("No supported rewrite found for file type: %s", file.Prefix)
 	}
 
-	// Iterate over the commit map and replace the old commit hashes with the new ones
-	for _, commit := range *commitMap {
-		replaceSHA(dataMap, commit.Old, commit.New)
-	}
-
-	// Marshal the updated data to JSON and pretty print it
+	// Pretty print the data
 	updatedData, err := json.MarshalIndent(dataMap, "", "  ")
 	if err != nil {
 		return fmt.Errorf("Error marshaling updated data: %v", err)
 	}
 
-	// Overwrite the original file with the updated data
-	err = os.WriteFile(filePath, updatedData, 0644)
+	err = os.WriteFile(file.FilePath, updatedData, 0644)
 	if err != nil {
 		return fmt.Errorf("Error writing updated data: %v", err)
 	}
@@ -101,29 +139,20 @@ func updateMetadataFile(filePath string, commitMap *[]CommitMapEntry) error {
 	return nil
 }
 
-func replaceSHA(data interface{}, oldSHA string, newSHA string) {
-	if data == nil {
-		return
-	}
-
-	switch v := data.(type) {
-	case map[string]interface{}:
-		for key, value := range v {
-			if str, ok := value.(string); ok && str == oldSHA {
-				v[key] = newSHA
-			} else {
-				replaceSHA(value, oldSHA, newSHA)
-			}
+func getAllFilesToProcess(prefixes []string, archiveLocation string) []File {
+	var files []File
+	for _, prefix := range prefixes {
+		// Get a list of all filePaths that match the pattern
+		filePaths, err := filepath.Glob(filepath.Join(archiveLocation, prefix+"_*.json"))
+		for _, filePath := range filePaths {
+			files = append(files, File{
+				FilePath: filePath,
+				Prefix:   prefix,
+			})
 		}
-	case []interface{}:
-		for i, value := range v {
-			if str, ok := value.(string); ok && str == oldSHA {
-				v[i] = newSHA
-			} else {
-				replaceSHA(value, oldSHA, newSHA)
-			}
+		if err != nil {
+			log.Fatalf("Error getting files: %v", err)
 		}
-	default:
-		// Unsupported type, do nothing
 	}
+	return files
 }

--- a/internal/commitremap/commitremap.go
+++ b/internal/commitremap/commitremap.go
@@ -41,11 +41,10 @@ func ParseCommitMap(filePath string) (*map[string]string, error) {
 			continue
 		}
 		fields := strings.Split(line, " ")
-		oldSha, newSha := fields[0], fields[1]
-
 		if len(fields) != 2 {
 			return nil, fmt.Errorf("invalid line: %s", line)
 		}
+		oldSha, newSha := fields[0], fields[1]
 		commitMap[oldSha] = newSha
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/commitremap/commitremap.go
+++ b/internal/commitremap/commitremap.go
@@ -48,6 +48,9 @@ func ParseCommitMap(filePath string) (*map[string]string, error) {
 		}
 		commitMap[oldSha] = newSha
 	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
 	return &commitMap, nil
 }
 

--- a/internal/commitremap/commitremap.go
+++ b/internal/commitremap/commitremap.go
@@ -44,7 +44,7 @@ func ParseCommitMap(filePath string) (*map[string]string, error) {
 
 func ProcessFiles(archiveLocation string, prefixes []string,
 	commitMap *map[string]string, workers int) error {
-	workerCount := 10
+	workerCount := workers
 	fileChannel := make(chan File, workerCount)
 	fileProcessWg := sync.WaitGroup{}
 	filesToProcess := getAllFilesToProcess(prefixes, archiveLocation)

--- a/internal/commitremap/updatemodels.go
+++ b/internal/commitremap/updatemodels.go
@@ -1,0 +1,93 @@
+package commitremap
+
+func updatePullRequests(commitMap map[string]string, pullRequests *[]interface{}) error {
+	for _, pr := range *pullRequests {
+		if prMap, ok := pr.(map[string]interface{}); ok {
+			// head_sha, base_sha, merge_commit_sha
+			if headMap, ok := prMap["head"].(map[string]interface{}); ok {
+				if headSha, ok := headMap["sha"].(string); ok {
+					if newSha, ok := commitMap[headSha]; ok {
+						headMap["sha"] = newSha
+					}
+				}
+			}
+			if baseMap, ok := prMap["base"].(map[string]interface{}); ok {
+				if baseSha, ok := baseMap["sha"].(string); ok {
+					if newSha, ok := commitMap[baseSha]; ok {
+						baseMap["sha"] = newSha
+					}
+				}
+			}
+			if mergeCommitSha, ok := prMap["merge_commit_sha"].(string); ok {
+				if newSha, ok := commitMap[mergeCommitSha]; ok {
+					prMap["merge_commit_sha"] = newSha
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func updatePullRequestReviews(commitMap map[string]string, pullRequestReview *[]interface{}) error {
+	for _, prr := range *pullRequestReview {
+		if prrMap, ok := prr.(map[string]interface{}); ok {
+			if headSha, ok := prrMap["head_sha"].(string); ok {
+				if newSha, ok := commitMap[headSha]; ok {
+					prrMap["head_sha"] = newSha
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func updatePullRequestReviewComments(commitMap map[string]string, pullRequestReviewComments *[]interface{}) error {
+	for _, prrc := range *pullRequestReviewComments {
+		if prrcMap, ok := prrc.(map[string]interface{}); ok {
+			// commit_id, original_commit_id
+			if commitId, ok := prrcMap["commit_id"].(string); ok {
+				if newSha, ok := commitMap[commitId]; ok {
+					prrcMap["commit_id"] = newSha
+				}
+			}
+			if originalCommitId, ok := prrcMap["original_commit_id"].(string); ok {
+				if newSha, ok := commitMap[originalCommitId]; ok {
+					prrcMap["original_commit_id"] = newSha
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func updatePullRequestReviewThreads(commitMap map[string]string, pullRequestReviewThreads *[]interface{}) error {
+	for _, prrt := range *pullRequestReviewThreads {
+		if prrtMap, ok := prrt.(map[string]interface{}); ok {
+			if commitId, ok := prrtMap["commit_id"].(string); ok {
+				if newSha, ok := commitMap[commitId]; ok {
+					prrtMap["commit_id"] = newSha
+				}
+			}
+			if originalCommitId, ok := prrtMap["original_commit_id"].(string); ok {
+				if newSha, ok := commitMap[originalCommitId]; ok {
+					prrtMap["original_commit_id"] = newSha
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func updateCommitComments(commitMap map[string]string, commitComments *[]interface{}) error {
+	for _, cc := range *commitComments {
+		if ccMap, ok := cc.(map[string]interface{}); ok {
+			// commit_id
+			if commitId, ok := ccMap["commit_id"].(string); ok {
+				if newSha, ok := commitMap[commitId]; ok {
+					ccMap["commit_id"] = newSha
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/internal/commitremap/updatemodels.go
+++ b/internal/commitremap/updatemodels.go
@@ -31,6 +31,7 @@ func updatePullRequests(commitMap map[string]string, pullRequests *[]interface{}
 func updatePullRequestReviews(commitMap map[string]string, pullRequestReview *[]interface{}) error {
 	for _, prr := range *pullRequestReview {
 		if prrMap, ok := prr.(map[string]interface{}); ok {
+			// head_sha
 			if headSha, ok := prrMap["head_sha"].(string); ok {
 				if newSha, ok := commitMap[headSha]; ok {
 					prrMap["head_sha"] = newSha
@@ -63,6 +64,7 @@ func updatePullRequestReviewComments(commitMap map[string]string, pullRequestRev
 func updatePullRequestReviewThreads(commitMap map[string]string, pullRequestReviewThreads *[]interface{}) error {
 	for _, prrt := range *pullRequestReviewThreads {
 		if prrtMap, ok := prrt.(map[string]interface{}); ok {
+			// commit_id, original_commit_id
 			if commitId, ok := prrtMap["commit_id"].(string); ok {
 				if newSha, ok := commitMap[commitId]; ok {
 					prrtMap["commit_id"] = newSha


### PR DESCRIPTION
This large PR (sorry ya'll) makes performance improvements by:
* Changing the comparison from an O(n^2) alg to O(n) by storing the commit-map content as a map with the old sha as the key vs comparing each old sha to the json value
* Processing each file in an individual goroutine
* Only processing the files that can possibly contain sha objects
* Only processing the fields that can possibly contain sha objects

For comparison, I tested on an large archive file (happy to give you a copy for testing 😄) containing a repo with 50k commits in the default branch that contained 138,100 metadata objects (1381 files * 100 objects per file) and a commit-map with 627k lines. Each file took ~1 minute per file to process with a total resulting in > 24 hours to rewrite the archive. With the new improvements, I was able to process the 1381 files in 12 seconds
```
Processed 1380/1381 files
./run.sh  12.00s user 3.44s system 99% cpu 15.486 total
```
Because of the threading, the memory footprint increases, but not significantly, for the default 10 go routines on 1.3k files, the go memory profiler indicates < 100mb which is ~2x the size of the commit-map file in this test. It would be possible to optimize this using buffers on the commit-map reads, but I imagine performance might decrease having to make multiple syscalls to read the file.

![CleanShot 2024-09-06 at 16 29 06@2x](https://github.com/user-attachments/assets/7d14bc7b-0e5f-496f-955f-c38cb2480be8)

In addition, this also adds QoL changes for:
* Adding a new optional flag to specify the number of threads to use for processing
* Adds buffers for reads on the metadata files
* Prints the count of files processed vs the total count
* Adds a log file of all of the processed files instead of printing to stdout