### PR TITLE
update release to use go.mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
-      - uses: cli/gh-extension-precompile@v1
+      - uses: cli/gh-extension-precompile@9e2237c30f869ad3bcaed6a4be2cd43564dd421b #v2.1.0
         with:
-          go_version: 1.21
+          go_version_file: go.mod


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases by upgrading the `cli/gh-extension-precompile` action and improving how the Go version is specified.

Workflow improvements:

* Updated the `cli/gh-extension-precompile` action from version 1 to version 2.1.0, referencing a specific commit for better reliability.
* Changed the Go version specification from a hardcoded version (`go_version: 1.21`) to referencing the version in `go.mod` (`go_version_file: go.mod`), ensuring consistency with the project's dependencies.