### PR TITLE
Add Release Drafter process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+<!--
+## Release Drafter
+
+This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:
+
+- `major` label will be a major version
+- `minor` or `enhancement` will bump it to a minor version
+- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
+-->
+
+## Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
+
+## Checklist
+
+<!-- - [ ] Issue linked if existing -->
+- [ ] I have added the appropriate label to this PR according to the type of change
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests
+
+## Additional Context
+
+Add any other context or screenshots about the pull request here.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,38 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🩹 Patches'
+    labels:
+      - 'patch'
+      - 'dependencies'
+      - 'security'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER) 🚢'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+      - 'bug'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter Update
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - '.github/**'
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

Ports the Release Drafter so this repo automatically maintains draft release notes and resolves the next version from PR labels. On every merge to `main`, Release Drafter groups merged PRs into categorized changelog sections and computes the version bump; the existing `release.yml` still handles publishing precompiled binaries when a `v*` tag is pushed.

Adds three files:

- `.github/release-drafter.yml` - changelog categories, version resolver, and release note template.
- `.github/workflows/release-drafter.yml` - workflow that updates the draft release on pushes to `main`.
- `.github/pull_request_template.md` - documents the labeling scheme that drives versioning and categorization, plus a contributor checklist.


## Checklist

<!-- - [ ] Issue linked if existing -->
- [x] I have added the appropriate label to this PR according to the type of change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

N/A