### PR TITLE
set maxMatchedFileSize as int64 for 32-bit compilation

### DIFF
--- a/pkg/archive/stream.go
+++ b/pkg/archive/stream.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mona-actions/gh-commit-remap/pkg/commitremap"
 )
 
-const maxMatchedFileSize = 2 << 30 // 2 GB guard for matched entries
+const maxMatchedFileSize int64 = 2 << 30 // 2 GB guard for matched entries
 
 // StreamRemap reads a .tar.gz migration archive, remaps SHAs in matching
 // JSON metadata files in-flight, and writes the result to a new .tar.gz.


### PR DESCRIPTION
<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

This pull request makes a small change to the `pkg/archive/stream.go` file to explicitly specify the type of the `maxMatchedFileSize` constant as `int64`. This helps with cross-compiles for 32-bit targets (386, arm) where Go's int is 32 bits (max 2147483647)

failed run: https://github.com/mona-actions/gh-commit-remap/actions/runs/28826036404

## Checklist

<!-- - [ ] Issue linked if existing -->
- [x] I have added the appropriate label to this PR according to the type of change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests

## Additional Context

Add any other context or screenshots about the pull request here.
